### PR TITLE
Update go test github action

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23.6'
+        go-version-file: 'go.mod'
     - name: Get dependencies
       run: go mod tidy
     - name: Build


### PR DESCRIPTION
to use go version based on the one specified in go.mod reducing maintenance